### PR TITLE
Deprecate closest defender aggregates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Rails app to populate a PostgreSQL database containing every shot attempted in t
 
 Blog post with some analysis of the data: https://toddwschneider.com/posts/nba-vs-ncaa-basketball-shooting-performance/
 
-Data comes from the [NBA Stats API](https://stats.nba.com/). As of March 2018, the database contains ~4.5 million shots from 2,000 players, and takes up 1.5 GB disk space. Database also includes player/season aggregates segmented by shot distance and the distance of the closest defender at the time of the shot. Closest defender info is not available for individual shots, but the aggregates are available in the `closest_defender_aggregates` table.
+Data comes from the [NBA Stats API](https://stats.nba.com/). As of March 2018, the database contains ~4.5 million shots from 2,000 players, and takes up 1.5 GB disk space.
 
 ## NCAA men's college basketball data
 
@@ -39,22 +39,16 @@ lebron.create_shots(season: "2017-18", season_type: "Regular Season")
 Delayed::Worker.new.work_off
 ```
 
-or
-
-```rb
-ClosestDefenderAggregate.create_by(
-  season: "2017-18",
-  season_type: "Regular Season",
-  shot_distance_range: "17-18",
-  closest_defender_range: "2-4 Feet - Tight"
-)
-Delayed::Worker.new.work_off
-```
-
 ## Notes
 
 - `player#create_shots` uses Postgres's `COPY` command instead of Rails's `#create` method because `COPY` is ~10x faster
 - Shots have no natural unique identifier: no external IDs, no guarantee that there's only 1 shot from 1 player at the same second of the same game, etc. Accordingly, `player#create_shots` deletes and replaces data every time it is run.
+
+## Closest defender aggregates [Deprecated]
+
+The original version of this project had a table called `closest_defender_aggregates` that included player/season aggregates segmented by shot distance and the distance of the closest defender at the time of the shot.
+
+Unfortunately, as of December 2020 (and perhaps earlier), it seems like the NBA API no longer makes this data available. The `NbaStatsClient#shot_stats_by_closest_defender` method currently only seems to work if the `shot_dist_range` argument is empty. This means you can get a player's shooting performance segmented by closest defender distance, but you cannot further segment by shot distance.
 
 ## See also
 

--- a/app/lib/nba_stats_client.rb
+++ b/app/lib/nba_stats_client.rb
@@ -53,7 +53,11 @@ class NbaStatsClient
     get(path: "shotchartdetail", params: params)
   end
 
-  def shot_stats_by_closest_defender(season:, shot_dist_range:, close_def_dist_range:, season_type: "Regular Season")
+  def shot_stats_by_closest_defender(season:, shot_dist_range: nil, close_def_dist_range:, season_type: "Regular Season")
+    if shot_dist_range.present?
+      raise "As of December 2020, it appears that the shot_dist_range filter is no longer supported by the NBA API"
+    end
+
     raise "invalid season" unless closest_defender_seasons.include?(season)
     raise "invalid season type" unless season_types.include?(season_type)
     raise "invalid defender range" unless closest_defender_ranges.include?(close_def_dist_range)

--- a/lib/tasks/import_all_shots.rake
+++ b/lib/tasks/import_all_shots.rake
@@ -1,4 +1,3 @@
 task import_all_shots: :environment do
   Shot.create_all
-  ClosestDefenderAggregate.create_all
 end


### PR DESCRIPTION
NBA API no longer seems to make this data available